### PR TITLE
Add validators to shopping cart model

### DIFF
--- a/app/models/shopping_cart.rb
+++ b/app/models/shopping_cart.rb
@@ -4,5 +4,18 @@ class ShoppingCart < ApplicationRecord
 
   validates :order, presence: true
   validates :product, presence: true
-  validates :quantity, presence: true
+  validates :quantity, presence: true, numericality: {greater_than: 0}
+  validate :order_product_combination
+
+  # Ensure no more than one same product order combination
+  # For instance, if there is a shopping cart with in the 
+  # format {product_id: 1, order_id: 1, quantity: 1}, a user
+  # should not be allowed to create another shopping cart 
+  # with the same combination. ie, same product_id and order_id.
+  def order_product_combination
+    shopping_carts = ShoppingCart.where("order_id = ?", order_id)
+    if(!shopping_carts.find_by(product_id: product_id).nil?)
+      errors.add(:invalid_cart_creation, "product with id=#{product_id} already exists in this cart. You can either remove it, or change its quantity in the cart")
+    end
+  end
 end


### PR DESCRIPTION
One validator ensures that the quantity never goes below 1. There should always be more or one of a product in the cart

The other validator ensures that there is never more than one combination of product_id and order_id in the shopping_cart. For instance, if one shopping cart is of the form
{product_id: 1, order_id: 1, quantity: 1}, there should never be another in the form {product_id: 1, quantity_id: 1, quantity: 3} regardless of the quantity. This forces changing quantity to involve updating the quantity and not posting a new shopping_cart